### PR TITLE
Adding versioning to the client

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -9,10 +9,10 @@
 // Name of client reported in the 'version' message. Report the same name
 // for both bitcoind and bitcoin-qt, to make it harder for attackers to
 // target servers or GUI users specifically.
-const std::string CLIENT_NAME("Satoshi");
+const std::string CLIENT_NAME("Crafty");
 
 // Client version number
-#define CLIENT_VERSION_SUFFIX   "-foo"
+#define CLIENT_VERSION_SUFFIX   "-crc"
 
 
 // The following part of the code determines the CLIENT_BUILD variable.

--- a/src/version.h
+++ b/src/version.h
@@ -12,10 +12,10 @@
 //
 
 // These need to be macro's, as version.cpp's voodoo requires it
-#define CLIENT_VERSION_MAJOR       1
-#define CLIENT_VERSION_MINOR       0
-#define CLIENT_VERSION_REVISION    0
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_MAJOR       0
+#define CLIENT_VERSION_MINOR       1
+#define CLIENT_VERSION_REVISION    1
+#define CLIENT_VERSION_BUILD       1
 
 static const int CLIENT_VERSION =
                            1000000 * CLIENT_VERSION_MAJOR


### PR DESCRIPTION
This should make the version in the "About Craftcoin" section display an accurate version, and not foocoin's.

Just make sure to update version.h with the proper numbers when you compile a new version.
