### PR TITLE
Add switch for new difficulty rule

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -25,7 +25,7 @@ namespace Checkpoints
     static MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of // Yo dawg, this is the secret. Checkpoint 0 hash == Genesis block hash.
         (         0, uint256("0x64a9141746cbbe06c7e1a4b7f2abb968ccdeba66cd67c1add1091b29db00578e"))
-        (         1, uint256("0x8c6d02b02c996531baf1f29637cfe122dfffbe900961e9df9f4a12f4a9f42e2e"))
+        (         2, uint256("0x8c6d02b02c996531baf1f29637cfe122dfffbe900961e9df9f4a12f4a9f42e2e"))
         (      1000, uint256("0xb2c469e23698d422d82e8a2e0f311b6b9e53fd834b552009479d0fe28abfae7a"))
         (      2400, uint256("0xe0ffcb739214da82050985be90b20365f0edead5ce3723b959f5ef24478a7e0a"))
         (      9275, uint256("0xaaccac8516a4c455f80471b868b30aaa2c75d7e897c63ef9953df3f596495cad"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -837,6 +837,8 @@ static const int64 nTargetTimespan = 1 * 60 * 60; // CraftCoin: 1 hour
 static const int64 nTargetSpacing = 300; // CraftCoin: 5 minute blocks
 static const int64 nInterval = nTargetTimespan / nTargetSpacing;
 
+static const int nDifficultyFork = 9328;
+
 // Thanks: Balthazar for suggesting the following fix
 // https://bitcointalk.org/index.php?topic=182430.msg1904506#msg1904506
 static const int64 nReTargetHistoryFact = 6; // look at 6 times the retarget
@@ -1790,7 +1792,7 @@ bool CBlock::AcceptBlock()
     int nHeight = pindexPrev->nHeight+1;
 
     // Check proof of work
-    if (nBits != GetNextWorkRequired(pindexPrev, this))
+    if ((fTestNet || nHeight >= nDifficultyFork) && nBits != GetNextWorkRequired(pindexPrev, this))
         return DoS(100, error("AcceptBlock() : incorrect proof of work"));
 
     // Check timestamp against prev


### PR DESCRIPTION
This fixes a typo in the checkpoints and passes blocks up to the last checkpoint, even though they use the old rule.

The switch to the new rule happens at block 9328 so that it is in advance of the last checkpoint.

There is no difficulty update from 9328 and 9332, so the rule can be applied early.

This means that the 9332 checkpoint is a post rule change checkpoint.
