### PR TITLE
Add sendalert rpc call

### DIFF
--- a/src/alertgen.cpp
+++ b/src/alertgen.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2011-2012 
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Key Generation
+//
+// Generate private key
+//
+//    openssl ecparam -out key.pem -name secp256k1 -genkey
+//
+// Print out key pair
+//
+//    openssl ec -inform PEM -in key.pem  -pubout -text -noout
+//
+// Take the public key (pub) and remove all : symbols and convert into a
+// single line.
+// 
+// Paste this hex string as the alert public key in main.h
+//
+// Search for CheckSignature and key.SetPubKey(ParseHex("..."))
+// 
+// This updates the public key so clients will accept alerts from the 
+// private key
+//
+// Encoding private key
+//
+// Note: The private key must be kept secure
+//
+// Convert the private key to der format
+//
+//    openssl ec -inform pem -in key.pem -param_enc explicit -outform der -out key.der 
+//
+// Convert the der format to a hex representation of the private key
+//
+//    xxd -p key.der
+// 
+// Alerts can be sent from the command line using the rpc interface.
+// Replace 30...4b with the private key as a single line hex string.
+// The private key has a length of 279 bytes (558 characters)
+//
+// ./craftcoind sendalert 30 "The alert message" 1376433494 21 21 30...4b
+//
+//////////////////////////////////////////////////////////////////////////
+
+
+#include "main.h"
+#include "key.h"
+#include "alertgen.h"
+
+using namespace std;
+using namespace boost;
+
+CAlert GetAlert(int id, std::string message, int relayUntil, int priority, int cancelid, int expiration, std::string privateKey)
+{
+
+     CUnsignedAlert alert;
+
+     alert.SetNull();
+
+     alert.nRelayUntil = relayUntil;
+     alert.nExpiration = expiration;
+     alert.nID = id;
+     alert.nCancel = cancelid;
+     alert.nMinVer = 0;
+     alert.nMaxVer = PROTOCOL_VERSION + 10000;
+     alert.nPriority = priority;
+
+     alert.strStatusBar = message;
+
+     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+     s << alert;
+
+     CAlert signedAlert;
+     signedAlert.vchMsg.resize(s.size());
+     s.read((char*)&signedAlert.vchMsg[0], s.size());
+
+     CDataStream prKeySer(SER_NETWORK, PROTOCOL_VERSION);
+
+     prKeySer << ParseHex(privateKey);
+
+     CPrivKey prKey;
+     prKeySer >> prKey;
+
+     CKey key;
+     key.SetPrivKey(prKey);
+
+     key.Sign(Hash(signedAlert.vchMsg.begin(), signedAlert.vchMsg.end()), signedAlert.vchSig);
+
+     return signedAlert;
+
+}

--- a/src/alertgen.h
+++ b/src/alertgen.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2011-2012
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ALERT_GEN_H
+#define ALERT_GEN_H
+
+CAlert GetAlert(int id, std::string message, int relayUntil, int priority, int cancelid, int expiration, std::string privateKey);
+
+#endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -9,6 +9,7 @@
 #include "net.h"
 #include "init.h"
 #include "util.h"
+#include "alertgen.h"
 #include "ui_interface.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>

--- a/src/main.h
+++ b/src/main.h
@@ -1593,7 +1593,7 @@ public:
     bool CheckSignature()
     {
         CKey key;
-        if (!key.SetPubKey(ParseHex("040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9")))
+        if (!key.SetPubKey(ParseHex("04a54dc6c760d28eb9e33012434b38d6094d8306f26c1aeef7d3d69aac682d48325edbc19b72fa2267a29c37e252f72670eb6a60be26e58959af495e74e6c4989c")))
             return error("CAlert::CheckSignature() : SetPubKey failed");
         if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
             return error("CAlert::CheckSignature() : verify signature failed");

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -102,6 +102,7 @@ OBJS= \
     obj/key.o \
     obj/db.o \
     obj/init.o \
+    obj/alertgen.o \
     obj/irc.o \
     obj/keystore.o \
     obj/main.o \


### PR DESCRIPTION
This adds alert support for the rpc interface.

It would be more secure to have an offline signing computer.  However, this system works.

Instructions for generating the keys are included in the alertgen.cpp file.

I only tweaked the unix craftcoind build.  To build qt, the qt makefile would have to have alertgen added.

The parameters in the rpc call are

sendalert <id> <message> <relayuntil> [priority=20] [cancelid=0] [expiration=relayuntil] <privatekey>

id: The id of the message (new alerts should have a higher id than old ones)
message: The actual message (needs quotes if more than 1 word)
relayuntil: The unix timestamp for when to stop relaying the alert
priority: The priority of the message
cancelid: Cancels all alerts with an id less than or equal to this
expiration:  The unix timestamp for when to stop displaying the alert
privatekey: Hex representation of the 279 byte encoded private key

For priorities
1000 priority is warnings (like low disk space)
2000 priority is major warnings (chain reorg of more than 6 blocks)

2001 would guarantee that no system message has higher priority than the alert.
20 means display the alert unless there is a system message
