### PR TITLE
Low PoW blocks for block rate smoothing

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1885,7 +1885,8 @@ Value getworkex(const Array& params, bool fHelp)
         static int64 nStart;
         static CBlock* pblock;
         if (pindexPrev != pindexBest ||
-            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60))
+            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60) ||
+            (GetTime() - nStart > 300))
         {
             if (pindexPrev != pindexBest)
             {
@@ -1923,7 +1924,7 @@ Value getworkex(const Array& params, bool fHelp)
         char phash1[64];
         FormatHashBuffers(pblock, pmidstate, pdata, phash1);
 
-        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256() << pblock->powshift;
 
         CTransaction coinbaseTx = pblock->vtx[0];
         std::vector<uint256> merkle = pblock->GetMerkleBranch(0);
@@ -2017,7 +2018,8 @@ Value getwork(const Array& params, bool fHelp)
         static int64 nStart;
         static CBlock* pblock;
         if (pindexPrev != pindexBest ||
-            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60))
+            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60) ||
+            (GetTime() - nStart > 300))
         {
             if (pindexPrev != pindexBest)
             {
@@ -2055,7 +2057,7 @@ Value getwork(const Array& params, bool fHelp)
         char phash1[64];
         FormatHashBuffers(pblock, pmidstate, pdata, phash1);
 
-        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256() << pblock->powshift;
 
         Object result;
         result.push_back(Pair("midstate", HexStr(BEGIN(pmidstate), END(pmidstate)))); // deprecated
@@ -2144,7 +2146,8 @@ Value getblocktemplate(const Array& params, bool fHelp)
         static int64 nStart;
         static CBlock* pblock;
         if (pindexPrev != pindexBest ||
-            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 5))
+            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 5) ||
+            (GetTime() - nStart > 300))
         {
             nTransactionsUpdatedLast = nTransactionsUpdated;
             pindexPrev = pindexBest;
@@ -2208,7 +2211,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
         Object aux;
         aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
 
-        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256() << pblock->powshift;
 
         static Array aMutable;
         if (aMutable.empty())

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -496,7 +496,7 @@ bool CTxDB::LoadBlockIndex()
     BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
     {
         CBlockIndex* pindex = item.second;
-        pindex->bnChainWork = (pindex->pprev ? pindex->pprev->bnChainWork : 0) + pindex->GetBlockWork();
+        pindex->bnChainWork = (pindex->pprev ? pindex->pprev->bnChainWork : 0) + pindex->GetBlockAdjustedWork();
     }
 
     // Load hashBestChain pointer to end of best chain


### PR DESCRIPTION
The is a hard fork that where miners can submit low PoW blocks.  All blocks on the current chain would be valid since they meet the full PoW.

If a miner submits a block with 25% PoW, they only get 2.5 CRC minting fee and 25% of the transaction fees.

The rest of the minting and transaction fees are lost.

At least 30 minutes must have passed since the median of the last 11 blocks before low PoW blocks are accepted.  The minimum PoW accepted drops by a factor of 2 every 10 minutes.

0-30: 1X
30-40: 0.5X
40-50: 0.25X
50-60: 0.125X

The maximum reduction allowed is 1024.  However, that would require 130 minutes since the median of the last 11 blocks.  This could be made more strict later as a soft fork.  I felt better to give maximum flexibility for the hard fork.

The mining code never produces blocks with less than (1/32) X PoW.  Mining blocks with higher PoW than the minimum is allowed, so miners can keep mining full sized blocks if they wish.

I ran the code on an isolated network and it converged to 10 minutes per block over a night with just one GPU.  I did get lots of blocks with a reward of 0.020 CRC for a while.  Even at the start, blocks were being found reasonably quickly.

What is nice is the PoW drops the longer a block is not found.  This reduces variance.  If an hour passes with no block, then the PoW target would be 0.125X of the standard.

The 6 blocks confirmation system take into account the low PoW of some blocks.  The number of confirms for a transaction is adjusted for low PoW blocks.

The best chain calculations give reduced credit for low PoW blocks, so a chain of 1/1024 blocks that is 100 blocks long would be worth less than a single full PoW chain.

Connecting my node to the main network displaced my local fork, even though the main chain had fewer blocks.

It also changes the rules so that the retarget window is more than just the 12 blocks.  There is a variable that says when that change actually takes effect, and it was set to 15000.  I reduced it to 10000.  At 288 blocks per day, the switch would happen in the next few days.

---

VALIDATION RULE CHANGES

Low proof of work blocks are allowed
  time is measured relative to the median of last 11 blocks
  Scaling factor is 1 and doubles every 10 minutes starting at 30
  Hash target is multiplied by the scaling factor
  Block reward (and tx fees) are divided by the scaling factor
  The scaling factor must be a power of 2 (max 1024)
  Low PoW blocks are not mandatory, miners choose how much to reduce PoW

Block retarget is adjusted
  Coinfix reduced to block 10000 instead of 15000
    Only one retarget period is taken into account until then
  Increased coinfix history factor to 24 (1 day)

CheckProofOfWork() changed
  Shift input added to shift the target for checking low PoW blocks
  basic/fast checks confirm that PoW better than 1/1024 of standard
  The reduced minting reward is checked in ConnectBlock()
  The scaling factor delay is checked in AcceptBlock()

CONFIRMATION CHANGES

  The calculation for number of confirms takes into account reduced proof
    The work per block is estimated using the higher of the last block and
    the block 24 blocks deep.
    The work done since the transaction is divided by that amount to give
    the depth, rather than counting the number of blocks
    Transactions more than 120 blocks deep just use the raw count

MINING CHANGES

Low PoW blocks are generated
  40 minutes after the median of the last 11 blocks, the PoW is halved
  PoW is reduced by 2 every 10 mins after that
  Maximum reduction factor is 32X

Blocks are regenerated at least once every 5 mins
  Previously, the block was only regenerated if a new block or transaction was received
  This ensures that the PoW target drops every 10 mins if there is a hash dropoff

RPC Hash target is adjusted for low PoW blocks
